### PR TITLE
Added --overwrite-existing-translations option to the command, when t…

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -21,12 +21,17 @@ Its also possible to ignore certain groups or locales
 php artisan translations:import --ignore-groups=routes,defaults --ignore-locales=en,fr
 ```
 
+While it's turned of by default, we offer a way of overwriting all the existing translations
+```bash
+php artisan translations:import --overwrite-existing-translations
+```
+
 ## Installation
 
 You can install the package via composer: 
 
 ``` bash
-composer require wedesignit/laravel-translation-import
+composer require wedesignit/laravel-translations-import
 ```
 
 Optionally you could publish the config file to change table and column names.


### PR DESCRIPTION
…his option is given the user will be prompted confirm box.

When the user confirms the option, it will overwrite all existing translations.

Bugfix on the update method, removed '!' which would lead to a if that never passes.
Added the new option to the readme.
Fixed typo in readme